### PR TITLE
current_database_nameを追加する

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -8,6 +8,7 @@ module Apartment
       define_callbacks :create, :switch
 
       attr_writer :default_tenant
+      attr_reader :current_database_name
 
       #   @constructor
       #   @param {Hash} config Database config
@@ -77,6 +78,7 @@ module Apartment
             Apartment.connection.clear_query_cache
           end
         end
+        @current_database_name = tenant
       end
 
       #   Connect to tenant, do your biz, switch back to previous tenant
@@ -116,6 +118,7 @@ module Apartment
       #   Reset the tenant connection to the default
       #
       def reset
+        @current_database_name = nil
         Apartment.establish_connection @config
       end
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -3,6 +3,7 @@
 module Apartment
   module Adapters
     # Abstract adapter from which all the Apartment DB related adapters will inherit the base logic
+    # rubocop:disable Metrics/ClassLength
     class AbstractAdapter
       include ActiveSupport::Callbacks
       define_callbacks :create, :switch
@@ -274,5 +275,6 @@ module Apartment
       class SeparateDbConnectionHandler < ::ActiveRecord::Base
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -10,7 +10,8 @@ module Apartment
     extend Forwardable
 
     def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each,
-                   :reset, :init, :set_callback, :seed, :default_tenant, :environmentify
+                   :reset, :init, :set_callback, :seed, :default_tenant, :environmentify,
+                   :current_database_name
 
     attr_writer :config
 


### PR DESCRIPTION
## 関連リンク(asana, Slack, Issue)

https://classi.esa.io/posts/31396
https://github.com/classi/apartment/commit/83072699f1137412d2fa27baaa9d8166683949e9

## やりたいこと

ros-apartmentにcurrent_database_nameを追加する

## なぜなのか

連携サービス使っていたcurrent_databse_nameブランチはApartmentゲムですが、Rails 6.1にアップデートする際ros-apartmentが必要のでros-apartmentにcurrent_database_nameを追加する

## やったこと

- [x] Apartment::Tenant.current_database_name追加

## やらなかったこと

<!-- 例
- クエリチューニング
-->

## 見てほしいところ
<!--
- 自信がない箇所
- 雰囲気でやっている箇所
-->

## 確認方法

https://classi.esa.io/posts/31396

## キャプチャ

<!-- 例
UI の変更がある場合はキャプチャ画像を貼る
ただし直接貼るとprivateリポジトリでも **認証無しに閲覧可能**
- 社外秘資料のスクショなどはアップしない（Google Docsなりesaなりにアップした上でそのリンクを貼る）
- 実装中の画面のキャプチャ/スクショとかは、それ自体が社外秘に当たるようなもので、そのURL単体だけでそれがなにか分かってしまうようなものは避ける（未公開の新機能とかね）
- もし仮にヤバいやつアップしちゃったとしても、URL自体が漏れなければそれがよそに漏れる可能性は低いから、落ち着いて画像への参照リンクを消す
- それ以外で普通にLGTMとか改修箇所の限定的なキャプチャとかはまあ使っててもええんちゃう

|Before|After|
|:-:|:-:|
|![変更前](URL)|![変更後](URL)|

-->

## マージ後にやること

<!-- 例
- `bundle exec rails xxx:xxx` を実行
-->

